### PR TITLE
feat[backend] : implement liking a song logic and expose endpoints

### DIFF
--- a/backend/src/main/java/backend/controller/SongController.java
+++ b/backend/src/main/java/backend/controller/SongController.java
@@ -1,7 +1,9 @@
 package backend.controller;
 
 import backend.dto.SongDTO;
+import backend.service.SongLikeService;
 import backend.service.SongService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
@@ -18,12 +20,22 @@ import java.util.List;
 @RestController
 @RequestMapping("/songs")
 @CrossOrigin("*")
+@RequiredArgsConstructor
 public class SongController {
 
     private final SongService songService;
 
-    public SongController(SongService songService) {
+  /*  public SongController(SongService songService) {
         this.songService = songService;
+    }*/
+
+    private final SongLikeService songLikeService;
+
+    @PostMapping("/{songId}/like")
+    public ResponseEntity<Void> toggleLike(@PathVariable Long songId,
+                                           @RequestParam Long userId) {
+        songLikeService.toggleLike(userId, songId);
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping
@@ -89,5 +101,9 @@ public class SongController {
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .body(resource);
+    }
+    @GetMapping("/like")
+    public ResponseEntity<List<SongDTO>> getLikedSongs(@RequestParam Long userId) {
+        return ResponseEntity.ok(songLikeService.getLikedSongs(userId));
     }
 }

--- a/backend/src/main/java/backend/model/SongLike.java
+++ b/backend/src/main/java/backend/model/SongLike.java
@@ -16,16 +16,15 @@ public class SongLike {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-
     private Long id;
 
-    // Stop the infinite loop!
+    // Stop the infinite loop
     @ToString.Exclude
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    // Stop the infinite loop!
+    // Stop the infinite loop
     @ToString.Exclude
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "song_id", nullable = false)

--- a/backend/src/main/java/backend/model/SongLike.java
+++ b/backend/src/main/java/backend/model/SongLike.java
@@ -1,0 +1,36 @@
+package backend.model;
+
+import jakarta.persistence.*;
+import lombok.*; // Import all lombok stuff
+import org.hibernate.annotations.CreationTimestamp;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "song_likes", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "song_id"})
+})
+@Getter // Replaces @Data part 1
+@Setter // Replaces @Data part 2
+@NoArgsConstructor // Replaces @Data part 3
+public class SongLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+
+    private Long id;
+
+    // Stop the infinite loop!
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // Stop the infinite loop!
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "song_id", nullable = false)
+    private Song song;
+
+    @CreationTimestamp
+    private LocalDateTime likedAt;
+}

--- a/backend/src/main/java/backend/repository/SongLikeRepository.java
+++ b/backend/src/main/java/backend/repository/SongLikeRepository.java
@@ -1,0 +1,16 @@
+package backend.repository;
+
+import backend.model.SongLike;
+import backend.model.User;
+import backend.model.Song;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.Optional;
+
+public interface SongLikeRepository extends JpaRepository<SongLike, Long> {
+    // Check if a specific user liked a specific song
+    Optional<SongLike> findByUserAndSong(User user, Song song);
+
+    // Get all songs liked by a user (for the "Liked Songs" playlist)
+    List<SongLike> findByUserOrderByLikedAtDesc(User user);
+}

--- a/backend/src/main/java/backend/service/SongLikeService.java
+++ b/backend/src/main/java/backend/service/SongLikeService.java
@@ -1,0 +1,65 @@
+package backend.service;
+
+import backend.model.Song;
+import backend.model.SongLike;
+import backend.model.User;
+import backend.repository.SongLikeRepository;
+import backend.repository.DBSongRepository;
+import backend.repository.DBUserRepository;
+import backend.dto.SongDTO;
+import backend.mapper.SongMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SongLikeService {
+
+    private final SongLikeRepository songLikeRepository;
+    private final DBSongRepository songRepository;
+    private final DBUserRepository userRepository;
+    private final SongMapper songMapper;
+    @Transactional
+    public boolean toggleLike(Long userId, Long songId) {
+        // fetch User and Song, error if not found
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found with ID: " + userId));
+
+        Song song = songRepository.findById(songId)
+                .orElseThrow(() -> new RuntimeException("Song not found with ID: " + songId));
+
+        // check if the like exists
+        Optional<SongLike> existingLike = songLikeRepository.findByUserAndSong(user, song);
+
+        if (existingLike.isPresent()) {
+            // UNLIKE: remove
+            songLikeRepository.delete(existingLike.get());
+            return false; // Return false to indicate "Not Liked"
+        } else {
+            // LIKE: add it
+            SongLike newLike = new SongLike();
+            newLike.setUser(user);
+            newLike.setSong(song);
+            songLikeRepository.save(newLike);
+            return true; // Return true to indicate "Liked"
+        }
+    }
+    public List<SongDTO> getLikedSongs(Long userId) {
+        // Find the user
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        //  Get the likes from the repo
+        List<SongLike> likes = songLikeRepository.findByUserOrderByLikedAtDesc(user);
+
+        //  Convert List<SongLike> -> List<SongDTO>
+        return likes.stream()
+                .map(like -> like.getSong())      // Extract the Song entity
+                .map(songMapper::toDTO)           // Convert to DTO (Check if your mapper uses toDto or toDTO)
+                .toList();
+    }
+}

--- a/backend/src/main/resources/db/migration/V9__create_song_likes.sql
+++ b/backend/src/main/resources/db/migration/V9__create_song_likes.sql
@@ -1,0 +1,13 @@
+CREATE TABLE song_likes (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    song_id BIGINT NOT NULL,
+    liked_at TIMESTAMP,
+
+    -- fk link to  existing tables
+    CONSTRAINT fk_song_likes_user FOREIGN KEY (user_id) REFERENCES users (id),
+    CONSTRAINT fk_song_likes_song FOREIGN KEY (song_id) REFERENCES songs (id),
+
+    -- Unique constraint,so a user cant like the same song twice
+    CONSTRAINT uk_user_song UNIQUE (user_id, song_id)
+);


### PR DESCRIPTION
- created SongLike entity and SongLikeRepository
- added V9 migration for song_likes table
- in SongLikeService, logic for toggleLike (for like/unlike) and SongMapper returns SongDTOs 
- in SongController, GET (view liked songs) and POST endpoints 