### PR TITLE
[backend]: implement follow artists logic

### DIFF
--- a/backend/src/main/java/backend/controller/ArtistController.java
+++ b/backend/src/main/java/backend/controller/ArtistController.java
@@ -26,6 +26,17 @@ public class ArtistController {
         return ResponseEntity.ok(created);
     }
 
+    @PostMapping("/{artistId}/follow")
+    public ResponseEntity<Void> toggleFollow(@PathVariable Long artistId,
+                                             @RequestParam Long userId) {
+        artistService.toggleFollow(userId, artistId);
+        return ResponseEntity.ok().build();
+    }
+    @GetMapping("/follow")
+    public ResponseEntity<List<ArtistDTO>> getFollowedArtists(@RequestParam Long userId) {
+        return ResponseEntity.ok(artistService.getFollowedArtists(userId));
+    }
+
     @GetMapping("/{id}")
     public ResponseEntity<ArtistDTO> getArtistById(@PathVariable Long id) {
         ArtistDTO dto = artistService.getArtistById(id);

--- a/backend/src/main/java/backend/model/Artist.java
+++ b/backend/src/main/java/backend/model/Artist.java
@@ -1,5 +1,20 @@
 package backend.model;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/backend/src/main/java/backend/model/Artist.java
+++ b/backend/src/main/java/backend/model/Artist.java
@@ -1,21 +1,12 @@
 package backend.model;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import jakarta.persistence.*;
+import lombok.*;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Table(name = "artists")
@@ -40,4 +31,9 @@ public class Artist {
     @OneToMany(mappedBy = "artist", cascade = CascadeType.ALL)
     @Builder.Default
     private List<Song> songs = new ArrayList<>();
+
+    @ManyToMany(mappedBy = "followedArtists", fetch = FetchType.LAZY)
+    @ToString.Exclude
+    @Builder.Default
+    private Set<User> userFollowers = new HashSet<>();
 }

--- a/backend/src/main/java/backend/model/User.java
+++ b/backend/src/main/java/backend/model/User.java
@@ -10,7 +10,9 @@ import lombok.Setter;
 import lombok.ToString;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Table (name = "users")
@@ -32,5 +34,15 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     @Builder.Default
     private List<Playlist> playlists = new ArrayList<>();
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "user_followed_artists",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "artist_id")
+    )
+    @ToString.Exclude
+    @Builder.Default
+    private Set<Artist> followedArtists = new HashSet<>();
 
 }

--- a/backend/src/main/resources/db/migration/V10__user_followed_artists.sql
+++ b/backend/src/main/resources/db/migration/V10__user_followed_artists.sql
@@ -1,0 +1,7 @@
+CREATE TABLE user_followed_artists (
+    user_id BIGINT NOT NULL,
+    artist_id BIGINT NOT NULL,
+    PRIMARY KEY (user_id, artist_id),
+    CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users (id),
+    CONSTRAINT fk_artist FOREIGN KEY (artist_id) REFERENCES artists (id)
+);


### PR DESCRIPTION
[backend]: implement follow artists logic
-added V10 migration for user_followed_artists join table (see which user follows which artist, using only id)
- updated User and Artist entities with manytomany relationships
- toggleFollow logic, in Artist Service and get all the followed artists for a user
- POST and GET endpoint exposed